### PR TITLE
External links should be internal if Github

### DIFF
--- a/FluxFinder.cs
+++ b/FluxFinder.cs
@@ -13,7 +13,7 @@ namespace FluxFinder
 		public override string Name => "FluxFinder";
 		public override string Author => "NepuShiro";
 		public override string Version => VERSION_CONSTANT;
-		public override string Link => "https://git.nepu.men/NepuShiro/FluxFinder/";
+		public override string Link => "https://github.com/NepuShiro/FluxFinder/";
 
 		[AutoRegisterConfigKey]
 		private static ModConfigurationKey<bool> ENABLED = new ModConfigurationKey<bool>("enabled", "Should FluxFinder be Enabled?", () => true);


### PR DESCRIPTION
Changed external link to Github since the mod is hosted on Github. This also fixes ResoniteModUpdater CLI being unable to fetch the mod's DLL.